### PR TITLE
Fix wrong name in unban message

### DIFF
--- a/CommandUnban.cs
+++ b/CommandUnban.cs
@@ -58,7 +58,7 @@ namespace fr34kyn01535.GlobalBan
             }
             else
             {
-                UnturnedChat.Say("The player " + name + " was unbanned");
+                UnturnedChat.Say("The player " + name.Name + " was unbanned");
             }
         }
 


### PR DESCRIPTION
Fixes unban messages like "The player fr34kyn01535.GlobalBan.DatabaseManager+UnbanResult was unbanned"